### PR TITLE
Scheduled course depts

### DIFF
--- a/etl/etl_transcripts.py
+++ b/etl/etl_transcripts.py
@@ -73,6 +73,7 @@ def run_etl(conn):
   transform_transcripts.fix_no_yearlong_possible(conn)
   transform_transcripts.fix_cnc(conn)
   transform_transcripts.fall_yearlongs(conn, current_year)
+  transform_transcripts.insert_missing_transcript_categories(conn)
   conn.commit()
 
 if __name__ == '__main__':

--- a/etl/transform_transcripts.py
+++ b/etl/transform_transcripts.py
@@ -5,6 +5,13 @@ import numpy as np
 import postgres_credentials
 
 def insert_missing_transcript_categories(conn):
+        '''
+        This function will insert transcript categories where grade_id = 999999 as they do not exist for scheduled courses.
+        The transcript categories are identified based on the course prefix, which is the first
+        word in the course code. The transcript category mappings are stored in the public.departments table, which needs to be
+        manually kept up to date until we can get a better solution.
+        '''
+        # The public.departments table needs to be manually kept up to date until we can get a better solution.
         cursor = conn.cursor()
         print("Inserting missing transcript categories")
         # Defining the update query
@@ -20,14 +27,10 @@ def insert_missing_transcript_categories(conn):
         # Executing the UPDATE query
         cursor.execute(update_query)
 
-
-def map_departments(conn):
-        # were doing this instead of just mapping all departments to course codes because of historical course codes
-        # cursor = conn.cursor()
-        # currently this is done in powerbi
-        pass
-
 def fall_yearlongs(conn, school_year):
+        '''
+        docstring
+        '''
         cursor = conn.cursor()
         print("Reassigning grade_id for current Fall YL grades")
         update_query = """UPDATE public.transcripts
@@ -40,6 +43,9 @@ def fall_yearlongs(conn, school_year):
         cursor.execute(update_query)
 
 def clean_up(conn, school_year):
+        '''
+        docstring
+        '''
         cursor = conn.cursor()
         # TODO: Make this more flexible so it doesn't break if you import out of order
         delete_scheduled_courses_query = """DELETE FROM public.transcripts
@@ -60,6 +66,9 @@ def clean_up(conn, school_year):
         print("Cleaned up old records")
 
 def fix_no_yearlong_possible(conn):
+        '''
+        docstring
+        '''
         cursor = conn.cursor()
         print("Fixing courses where no year-long grade is possible...")
         # Defining the SELECT query
@@ -100,6 +109,9 @@ def fix_no_yearlong_possible(conn):
                         cursor.execute(update_query)
 
 def fix_cnc(conn):
+        '''
+        docstring
+        '''
         cursor = conn.cursor()
         print("Fixing grades where one semester is C/CN and the other is a letter grade...")
         # Defining the SELECT query
@@ -167,9 +179,10 @@ if __name__ == '__main__':
 
         conn.autocommit = True
 
-        # clean_up(conn, '2023 - 2024')
-        # fix_no_yearlong_possible(conn)
-        # fix_cnc(conn)
-        # fall_yearlongs(conn, '2023 - 2024')
+        # The year can be changed as reqired. When running without name == main, the year will be the current year.
+        clean_up(conn, '2023 - 2024')
+        fix_no_yearlong_possible(conn)
+        fix_cnc(conn)
+        fall_yearlongs(conn, '2023 - 2024')
         insert_missing_transcript_categories(conn)
         conn.commit()

--- a/etl/transform_transcripts.py
+++ b/etl/transform_transcripts.py
@@ -8,46 +8,55 @@ def insert_missing_transcript_categories(conn):
         '''
         This function will insert transcript categories where grade_id = 999999 as they do not exist for scheduled courses.
         The transcript categories are identified based on the course prefix, which is the first
-        word in the course code. The transcript category mappings are stored in the public.course_codes table, which needs to be
-        manually kept up to date until we can get a better solution.
+        word in the course code. The transcript category mappings are stored in the public.course_codes table, which needs to 
+        be manually kept up to date until we can get a better solution.
         '''
         # The public.course_codes table needs to be manually kept up to date until we can get a better solution.
         cursor = conn.cursor()
         print("Inserting missing transcript categories")
+
         # Defining the update query
         update_query = """
         UPDATE public.transcripts
         SET transcript_category = course_codes.transcript_category
         FROM public.course_codes
-        WHERE transcripts.course_code::text LIKE Course_codes.course_prefix || '%' 
+        WHERE transcripts.course_code::text LIKE course_codes.course_prefix || '%' 
         AND transcripts.grade_id = 999999;
         """
-        # add transcript categories to scheduled courses
         print(update_query)
+
         # Executing the UPDATE query
         cursor.execute(update_query)
 
 def fall_yearlongs(conn, school_year):
         '''
-        docstring
+        Reassigns grade_id for Fall YL grades when the year is the current year. We need to do this to
+        allow them to show up in powerBI. Typically Fll YL grades are filtered out because they are overwritten
+        by YL grades.
         '''
         cursor = conn.cursor()
-        print("Reassigning grade_id for current Fall YL grades")
+        print("Reassigning grade_id for current Fall YL grades...")
+        # Defining the UPDATE query
         update_query = """UPDATE public.transcripts
                         SET grade_description = \'current_fall_yl\',
                                 grade_id = 666666
                         WHERE (school_year = \'{school_year}\' AND
                                 grade_description = \'Fall Term Grades YL\');""".format(school_year = school_year)
         print(update_query)
+        
         # Executing the UPDATE query
         cursor.execute(update_query)
 
 def clean_up(conn, school_year):
         '''
-        docstring
+        This function removes records with grade_id = 999999, 888888, 777777, 666666 and restores Fall YL grades. 
+        This is done to prevent duplicates on a reimport because the grade_id is part of the primary key.
         '''
         cursor = conn.cursor()
         # TODO: Make this more flexible so it doesn't break if you import out of order
+        print("Cleaning up old records...")
+
+        # Defining the DELETE queries
         delete_scheduled_courses_query = """DELETE FROM public.transcripts
                           WHERE grade_id = 999999"""
         delete_transforms_query = """DELETE FROM public.transcripts
@@ -55,19 +64,24 @@ def clean_up(conn, school_year):
                                      OR grade_id = 777777
                                      OR grade_id = 666666)
                                      AND school_year = \'{school_year}\'""".format(school_year = school_year)
+        
+        # Defining the UPDATE query
         restore_fall_yl_query = """UPDATE public.transcripts
                                    SET grade_description = \'Fall Term Grades YL\', grade_id = 2154180
                                    WHERE (school_year != \'{school_year}\' 
                                    AND grade_id = 666666);""".format(school_year = school_year)
         
+        # Executing the queries
         cursor.execute(delete_scheduled_courses_query)
+        print('Deleted scheduled courses.')
         cursor.execute(delete_transforms_query)
+        print('Deleted transforms.')
         cursor.execute(restore_fall_yl_query)
-        print("Cleaned up old records")
+        print('Restored Fall YL grades.')
 
 def fix_no_yearlong_possible(conn):
         '''
-        docstring
+        This function will fix courses where no year-long grade is possible.
         '''
         cursor = conn.cursor()
         print("Fixing courses where no year-long grade is possible...")
@@ -181,8 +195,8 @@ if __name__ == '__main__':
 
         # The year can be changed as reqired. When running without name == main, the year will be the current year.
         # clean_up(conn, '2023 - 2024') # WARNING this will delete all records with grade_id = 999999, 888888, 777777, 666666
-        # fix_no_yearlong_possible(conn)
-        # fix_cnc(conn)
-        # fall_yearlongs(conn, '2023 - 2024')
+        fix_no_yearlong_possible(conn)
+        fix_cnc(conn)
+        fall_yearlongs(conn, '2023 - 2024')
         insert_missing_transcript_categories(conn)
         conn.commit()

--- a/etl/transform_transcripts.py
+++ b/etl/transform_transcripts.py
@@ -8,18 +8,18 @@ def insert_missing_transcript_categories(conn):
         '''
         This function will insert transcript categories where grade_id = 999999 as they do not exist for scheduled courses.
         The transcript categories are identified based on the course prefix, which is the first
-        word in the course code. The transcript category mappings are stored in the public.departments table, which needs to be
+        word in the course code. The transcript category mappings are stored in the public.course_codes table, which needs to be
         manually kept up to date until we can get a better solution.
         '''
-        # The public.departments table needs to be manually kept up to date until we can get a better solution.
+        # The public.course_codes table needs to be manually kept up to date until we can get a better solution.
         cursor = conn.cursor()
         print("Inserting missing transcript categories")
         # Defining the update query
         update_query = """
         UPDATE public.transcripts
-        SET transcript_category = departments.transcript_category
-        FROM public.departments
-        WHERE transcripts.course_code::text LIKE departments.course_prefix || '%' 
+        SET transcript_category = course_codes.transcript_category
+        FROM public.course_codes
+        WHERE transcripts.course_code::text LIKE Course_codes.course_prefix || '%' 
         AND transcripts.grade_id = 999999;
         """
         # add transcript categories to scheduled courses
@@ -180,9 +180,9 @@ if __name__ == '__main__':
         conn.autocommit = True
 
         # The year can be changed as reqired. When running without name == main, the year will be the current year.
-        clean_up(conn, '2023 - 2024')
-        fix_no_yearlong_possible(conn)
-        fix_cnc(conn)
-        fall_yearlongs(conn, '2023 - 2024')
+        # clean_up(conn, '2023 - 2024') # WARNING this will delete all records with grade_id = 999999, 888888, 777777, 666666
+        # fix_no_yearlong_possible(conn)
+        # fix_cnc(conn)
+        # fall_yearlongs(conn, '2023 - 2024')
         insert_missing_transcript_categories(conn)
         conn.commit()

--- a/etl/transform_transcripts.py
+++ b/etl/transform_transcripts.py
@@ -4,6 +4,29 @@ import pandas as pd
 import numpy as np
 import postgres_credentials
 
+def insert_missing_transcript_categories(conn):
+        cursor = conn.cursor()
+        print("Inserting missing transcript categories")
+        # Defining the update query
+        update_query = """
+        UPDATE public.transcripts
+        SET transcript_category = departments.transcript_category
+        FROM public.departments
+        WHERE transcripts.transcript_category::text LIKE departments.transcript_category || '%' 
+        AND transcripts.grade_id = 999999;
+        """
+        # add transcript categories to scheduled courses
+        print(update_query)
+        # Executing the UPDATE query
+        cursor.execute(update_query)
+
+
+def map_departments(conn):
+        # were doing this instead of just mapping all departments to course codes because of historical course codes
+        # cursor = conn.cursor()
+        # currently this is done in powerbi
+        pass
+
 def fall_yearlongs(conn, school_year):
         cursor = conn.cursor()
         print("Reassigning grade_id for current Fall YL grades")
@@ -144,8 +167,9 @@ if __name__ == '__main__':
 
         conn.autocommit = True
 
-        clean_up(conn, '2023 - 2024')
-        fix_no_yearlong_possible(conn)
-        fix_cnc(conn)
-        fall_yearlongs(conn, '2023 - 2024')
+        # clean_up(conn, '2023 - 2024')
+        # fix_no_yearlong_possible(conn)
+        # fix_cnc(conn)
+        # fall_yearlongs(conn, '2023 - 2024')
+        insert_missing_transcript_categories(conn)
         conn.commit()

--- a/etl/transform_transcripts.py
+++ b/etl/transform_transcripts.py
@@ -12,7 +12,7 @@ def insert_missing_transcript_categories(conn):
         UPDATE public.transcripts
         SET transcript_category = departments.transcript_category
         FROM public.departments
-        WHERE transcripts.transcript_category::text LIKE departments.transcript_category || '%' 
+        WHERE transcripts.course_code::text LIKE departments.course_prefix || '%' 
         AND transcripts.grade_id = 999999;
         """
         # add transcript categories to scheduled courses


### PR DESCRIPTION
Implemented transformation for assigning departments to scheduled courses, which are not assigned by blackbaud. The transcript categories are identified based on the course prefix, which is the first word in the course code. The transcript category mappings are stored in the public.course_codes table, which needs to be manually kept up to date until we can get a better solution.